### PR TITLE
Add docker workflow and do not use gh-pages branch for GitHub pages

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,3 +6,13 @@ tag = True
 [bumpversion:file:setup.cfg]
 search = version = {current_version}
 replace = version = {new_version}
+
+
+[bumpversion:file:Dockerfile]
+search = ghcr.io/computationalphysiology/mps_motion:v{current_version}
+replace = ghcr.io/computationalphysiology/mps_motion:v{new_version}
+
+
+[bumpversion:file:docs/install.md]
+search = ghcr.io/computationalphysiology/mps_motion:v{current_version}
+replace = ghcr.io/computationalphysiology/mps_motion:v{new_version}

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,9 +1,28 @@
 name: Github Pages
 
-on: [push]
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches:
+    - "**"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-22.04
     env:
       # Directory that will be published on github pages
@@ -23,12 +42,29 @@ jobs:
       - name: Build docs
         run: make docs
 
-      - name: Create requirements.txt for binder
-        run: echo 'mps-motion' > ${{ env.PUBLISH_DIR }}/requirements.txt
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/main'
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.PUBLISH_DIR }}
+          path: ${{ env.PUBLISH_DIR }}
+
+  # Single deploy job since we're just deploying
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,57 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches:
+      - "!*"
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: docker/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use github pages for docker image
-FROM ghcr.io/computationalphysiology/mps_motion:v0.1.1
+FROM ghcr.io/computationalphysiology/mps_motion:v0.2.9
 
 # Create user with a home directory
 ARG NB_USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Use github pages for docker image
+FROM ghcr.io/computationalphysiology/mps_motion:v0.1.1
+
+# Create user with a home directory
+ARG NB_USER
+ARG NB_UID=1000
+ENV USER ${NB_USER}
+ENV HOME /home/${NB_USER}
+
+# Copy current directory
+WORKDIR ${HOME}
+COPY . ${HOME}
+
+# Change ownership of home directory
+USER root
+RUN chown -R ${NB_UID} ${HOME}
+
+USER ${NB_USER}
+ENTRYPOINT []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04
+
+ARG REPO_BRANCH="main"
+ENV DEB_PYTHON_INSTALL_LAYOUT=deb_system
+
+# Install pip and git with apt
+RUN apt-get update && \
+    apt-get install -y python3-pip git zip unzip curl ffmpeg libsm6 libxext6 && \
+    && rm -rf /var/lib/apt/lists/*
+
+# We upgrade pip and setuptools
+RUN python3 -m pip install --no-cache-dir pip setuptools --upgrade
+
+WORKDIR /tmp
+
+# # Copy pyproject.toml first so that we done need to reinstall in case another file
+# # is changing after rebuiding docker image
+RUN git clone --branch ${REPO_BRANCH} --single-branch https://github.com/finsberg/mps_motion.git
+RUN python3 -m pip install --no-cache-dir ./mps_motion
+
+# We remove the contents of the temporary directory to minimize the size of the image
+RUN rm -rf /tmp

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,3 +9,10 @@ Alternatively you can install it directly from Github
 ```
 python3 -m pip install git+https://github.com/ComputationalPhysiology/mps_motion
 ```
+
+
+## Docker
+We also provide a pre-built docker image with all the dependencies and `mps-motion` installed. You pull this image using the command
+```
+docker pull ghcr.io/computationalphysiology/mps_motion:v0.2.9
+```


### PR DESCRIPTION
Binder does not work out of the box using a simple `requirements.txt`. Therefore we add a separate docker image with some special libraries (such as `ffmpeg libsm6 libxext6`). At the same time we also move to a more modern pipeline for GitHub pages by not pushing to the `gh-pages` branch but to use the GitHub action.